### PR TITLE
[BUGFIX] Add missing module short description

### DIFF
--- a/Resources/Private/Language/locallang_mod_web_popuppower.xlf
+++ b/Resources/Private/Language/locallang_mod_web_popuppower.xlf
@@ -9,6 +9,9 @@
 			<trans-unit id="mlang_labels_tabdescr" resname="mlang_labels_tabdescr">
 				<source>Dashboard module for slavlee/popup-power extension.</source>
 			</trans-unit>
+			<trans-unit id="mlang_labels_tablabel" resname="mlang_tabs_tab">
+				<source>Module for slavlee/popup-power extension.</source>
+			</trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
According to the [documentation](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.html#confval-labels) there must be a label with the key `mlang_labels_tablabel` that contains the short description of the module

![Bildschirmfoto 2024-04-19 um 11 08 29](https://github.com/slavlee/popup_power/assets/5416710/3993320b-35e0-426d-8fd7-36e2070a072f)
